### PR TITLE
feat: add support for setting your machine architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@ This repository contains the code to start a GitHub Actions runner on an AWS EC2
 ## Inputs
 | Input                 | Description                                                                                                        | Required for start | Default |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------|------------------- |---------|
+| arch                  | The AMI architecture                                                                                               | true               | x64     |
 | aws_home_dir          | The AWS AMI home directory to use for your runner. Will not start if not specified.                                | true               |         |
 | aws_iam_role          | The optional AWS IAM role to assume for provisioning your runner.                                                  | false              |         |
 | aws_image_id          | The machine AMI to use for your runner. This AMI can be a default but should have docker installed in the AMI.     | true               |         |
 | aws_instance_type     | The type of instance to use for your runner. For example: t2.micro, t4g.nano, etc. Will not start if not specified.| true               |         |
 | aws_region_name       | The AWS region name to use for your runner. Defaults to AWS_REGION                                                 | true               |         |
-| aws_root_device_size  | The root device size in GB to use for your runner.                                                                 | false              | The AMI default root disk size | 
+| aws_root_device_size  | The root device size in GB to use for your runner.                                                                 | false              | The AMI default root disk size |
 | aws_security_group_id | The AWS security group ID to use for your runner. Will use the account default security group if not specified.    | false              | The default AWS security group |
 | aws_subnet_id         | The AWS subnet ID to use for your runner. Will use the account default subnet if not specified.                    | false              | The default AWS subnet ID |
 | aws_tags              | The AWS tags to use for your runner, formatted as a JSON list. See `README` for more details.                      | false              |         |

--- a/src/start_aws_gha_runner/__main__.py
+++ b/src/start_aws_gha_runner/__main__.py
@@ -28,7 +28,10 @@ def main():
         .update_state("INPUT_EXTRA_GH_LABELS", "labels")
         .update_state("INPUT_AWS_HOME_DIR", "home_dir")
         .update_state("INPUT_INSTANCE_COUNT", "instance_count", type_hint=int)
-        .update_state("INPUT_AWS_ROOT_DEVICE_SIZE", "root_device_size", type_hint=int)
+        .update_state(
+            "INPUT_AWS_ROOT_DEVICE_SIZE", "root_device_size", type_hint=int
+        )
+        .update_state("INPUT_ARCHITECTURE", "arch")
         # This is the default case
         .update_state("AWS_REGION", "region_name")
         # This is the input case


### PR DESCRIPTION
This pull request introduces a new input parameter for specifying the architecture of the AMI in both the documentation and the codebase. The changes ensure that users can define the architecture (`arch`) when starting a GitHub Actions runner on AWS EC2.

### Documentation Updates:
* Added a new input parameter `arch` to the `README.md`, describing it as the AMI architecture with a default value of `x64`.

### Code Updates:
* Updated `src/start_aws_gha_runner/__main__.py` to include the new `arch` parameter (`INPUT_ARCHITECTURE`) in the state update process.