### PR TITLE
feat: add support for pulling the latest AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repository contains the code to start a GitHub Actions runner on an AWS EC2
 |-----------------------|--------------------------------------------------------------------------------------------------------------------|------------------- |---------|
 | aws_home_dir          | The AWS AMI home directory to use for your runner. Will not start if not specified.                                | true               |         |
 | aws_iam_role          | The optional AWS IAM role to assume for provisioning your runner.                                                  | false              |         |
-| aws_image_id          | The machine AMI to use for your runner. This AMI can be a default but should have docker installed in the AMI.     | true               |         |
+| aws_image_id          | The machine AMI to use for your runner. This AMI can be a default but should have docker installed in the AMI. If set to `latest`, aws_image_name is required     | true               |         |
+| aws_image_name        | The name of AMI you want to use, only required if you don't specify `aws_image_id`                                 | false              |         |
 | aws_instance_type     | The type of instance to use for your runner. For example: t2.micro, t4g.nano, etc. Will not start if not specified.| true               |         |
 | aws_region_name       | The AWS region name to use for your runner. Defaults to AWS_REGION                                                 | true               |         |
 | aws_root_device_size  | The root device size in GB to use for your runner.                                                                 | false              | The AMI default root disk size | 
@@ -45,7 +46,8 @@ jobs:
         id: aws-start
         uses: omsf/start-aws-gha-runner@v1.0.0
         with:
-          aws_image_id: ami-0f7c4a792e3fb63c8
+          aws_image_name: "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04)"
+          aws_image_id: latest
           aws_instance_type: g4dn.xlarge
           aws_home_dir: /home/ubuntu
         env:

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,10 @@ inputs:
     description: "The optional AWS IAM role to assume for provisioning your runner."
     required: false
   aws_image_id:
-    description: "The machine AMI to use for your runner. This AMI can be a default but should have docker installed in the AMI. Will not start if not specified."
+    description: "The machine AMI to use for your runner. This AMI can be a default but should have docker installed in the AMI. Will not start if not specified. If set to `latest`, `aws_image_name` is required"
     required: true
+  aws_image_name:
+    description: "The AMI name. Only required if `aws_image_id` is set to latest. Be as specific as possible. For example: Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04)"
   aws_instance_type:
     description: "The type of instance to use for your runner. For example: t2.micro, t4g.nano, etc. Will not start if not specified."
     required: true

--- a/src/start_aws_gha_runner/__main__.py
+++ b/src/start_aws_gha_runner/__main__.py
@@ -20,6 +20,7 @@ def main():
     builder = (
         EnvVarBuilder(env)
         .update_state("INPUT_AWS_IMAGE_ID", "image_id")
+        .update_state("INPUT_AWS_IMAGE_NAME", "image_name")
         .update_state("INPUT_AWS_INSTANCE_TYPE", "instance_type")
         .update_state("INPUT_AWS_SUBNET_ID", "subnet_id")
         .update_state("INPUT_AWS_SECURITY_GROUP_ID", "security_group_id")
@@ -28,7 +29,9 @@ def main():
         .update_state("INPUT_EXTRA_GH_LABELS", "labels")
         .update_state("INPUT_AWS_HOME_DIR", "home_dir")
         .update_state("INPUT_INSTANCE_COUNT", "instance_count", type_hint=int)
-        .update_state("INPUT_AWS_ROOT_DEVICE_SIZE", "root_device_size", type_hint=int)
+        .update_state(
+            "INPUT_AWS_ROOT_DEVICE_SIZE", "root_device_size", type_hint=int
+        )
         # This is the default case
         .update_state("AWS_REGION", "region_name")
         # This is the input case

--- a/src/start_aws_gha_runner/start.py
+++ b/src/start_aws_gha_runner/start.py
@@ -231,10 +231,6 @@ class StartAWS(CreateCloudInstance):
                 "runner_release": self.runner_release,
                 "labels": labels,
             }
-            if self.image_id == "latest" and not self.image_name:
-                raise ValueError(
-                    "Looking for latest image but name not provided"
-                )
             # We need to handle the case where someone wants to always use latest
             if self.image_id == "latest":
                 if not self.image_name:

--- a/src/start_aws_gha_runner/start.py
+++ b/src/start_aws_gha_runner/start.py
@@ -52,6 +52,7 @@ class StartAWS(CreateCloudInstance):
     repo: str
     region_name: str
     runner_release: str = ""
+    image_name: str = ""
     tags: list[dict[str, str]] = field(default_factory=list)
     gh_runner_tokens: list[str] = field(default_factory=list)
     root_device_size: int = 0
@@ -119,8 +120,28 @@ class StartAWS(CreateCloudInstance):
             except Exception as e:
                 raise Exception(f"Error parsing user data template: {e}")
 
+    def _fetch_latest_ami(
+        self, client, ami_name: str, owner: str = "amazon"
+    ) -> str:
+        out = client.describe_images(
+            Owners=[owner],
+            Filters=[
+                {
+                    "Name": "name",
+                    "Values": [f"{ami_name}*"],
+                },
+                {"Name": "state", "Values": ["available"]},
+            ],
+        )
+        images = out.get("Images", [])
+        newest = sorted(images, key=lambda i: i["CreationDate"], reverse=True)[
+            0
+        ]
+
+        return newest["ImageId"]
+
     def _modify_root_disk_size(self, client, params: dict) -> dict:
-        """ Modify the root disk size of the instance.
+        """Modify the root disk size of the instance.
 
         Parameters
         ----------
@@ -146,11 +167,15 @@ class StartAWS(CreateCloudInstance):
             if "DryRunOperation" in str(e):
                 image_options = client.describe_images(ImageIds=[self.image_id])
                 root_device_name = image_options["Images"][0]["RootDeviceName"]
-                block_devices = deepcopy(image_options["Images"][0]["BlockDeviceMappings"])
+                block_devices = deepcopy(
+                    image_options["Images"][0]["BlockDeviceMappings"]
+                )
                 for idx, block_device in enumerate(block_devices):
                     if block_device["DeviceName"] == root_device_name:
                         if self.root_device_size > 0:
-                            block_devices[idx]["Ebs"]["VolumeSize"] = self.root_device_size
+                            block_devices[idx]["Ebs"]["VolumeSize"] = (
+                                self.root_device_size
+                            )
                             params["BlockDeviceMappings"] = block_devices
                         break
             else:
@@ -206,6 +231,18 @@ class StartAWS(CreateCloudInstance):
                 "runner_release": self.runner_release,
                 "labels": labels,
             }
+            if self.image_id == "latest" and not self.image_name:
+                raise ValueError(
+                    "Looking for latest image but name not provided"
+                )
+            # We need to handle the case where someone wants to always use latest
+            if self.image_id == "latest":
+                if not self.image_name:
+                    raise ValueError(
+                        "Looking for latest image but name not provided"
+                    )
+                # This updates the image ID to the latest, will fail if image does not exist
+                self.image_id = self._fetch_latest_ami(ec2, self.image_name)
             params = self._build_aws_params(user_data_params)
             if self.root_device_size > 0:
                 params = self._modify_root_disk_size(ec2, params)


### PR DESCRIPTION
This PR adds the functionality and tests to support the pulling the latest AMI from AWS after conversation with @mikemhenry . Currently, we are only officially supporting AMIs from Amazon (although we do have the code in place to expand this in the future). This code is based off of the command found here: https://docs.aws.amazon.com/dlami/latest/devguide/find-dlami-id.html.